### PR TITLE
基于深度缩放图像大小

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
                     <input type="range" id="protrude" min="-0.5" max="0.5" value="0" step="0.01">
                 </div>
                 <div class="control-item">
-                    <label for="maxScale">最大放大倍率: <span id="maxScaleValue" class="value-display">1.20</span></label>
-                    <input type="range" id="maxScale" min="1" max="2" value="1.2" step="0.01">
+                    <label for="maxScale">最大放大倍率: <span id="maxScaleValue" class="value-display">1.10</span></label>
+                    <input type="range" id="maxScale" min="1" max="2" value="1.1" step="0.01">
                 </div>
                 <div class="control-item">
                     <label for="centerX">缩放中心X: <span id="centerXValue" class="value-display">0.50</span></label>
@@ -116,7 +116,7 @@
             <div class="control-group">
                 <h3>模糊效果</h3>
                 <div class="control-item">
-                    <label for="blurSize">模糊大小: <span id="blurSizeValue" class="value-display">10</span></label>
+                    <label for="blurSize">模糊大小: <span id="blurSizeValue" class="value-display">5</span></label>
                     <input type="range" id="blurSize" min="0" max="50" value="5" step="0.5">
                 </div>
                 <div class="control-item">

--- a/index.html
+++ b/index.html
@@ -57,8 +57,16 @@
                     <input type="range" id="protrude" min="-0.5" max="0.5" value="0" step="0.01">
                 </div>
                 <div class="control-item">
-                    <label for="maxScale">最大放大倍率: <span id="maxScaleValue" class="value-display">1.50</span></label>
+                    <label for="maxScale">最大放大倍率: <span id="maxScaleValue" class="value-display">1.20</span></label>
                     <input type="range" id="maxScale" min="1" max="2" value="1.2" step="0.01">
+                </div>
+                <div class="control-item">
+                    <label for="centerX">缩放中心X: <span id="centerXValue" class="value-display">0.50</span></label>
+                    <input type="range" id="centerX" min="0" max="1" value="0.5" step="0.01">
+                </div>
+                <div class="control-item">
+                    <label for="centerY">缩放中心Y: <span id="centerYValue" class="value-display">0.50</span></label>
+                    <input type="range" id="centerY" min="0" max="1" value="0.5" step="0.01">
                 </div>
             </div>
             

--- a/index.html
+++ b/index.html
@@ -56,6 +56,10 @@
                     <label for="protrude">突出程度: <span id="protrudeValue" class="value-display">0</span></label>
                     <input type="range" id="protrude" min="-0.5" max="0.5" value="0" step="0.01">
                 </div>
+                <div class="control-item">
+                    <label for="maxScale">最大放大倍率: <span id="maxScaleValue" class="value-display">1.50</span></label>
+                    <input type="range" id="maxScale" min="1" max="2" value="1.2" step="0.01">
+                </div>
             </div>
             
             <!-- 全息显示参数 -->

--- a/main.js
+++ b/main.js
@@ -60,7 +60,7 @@ function getUniforms() {
         'g_Texture0', 'g_Texture1', 'g_Texture2', 'g_Screen',
         'u_threshold', 'u_protrude', 'u_x_diff', 'u_y_diff',
         'u_scaleX', 'u_scaleY', 'u_offsetX', 'u_offsetY',
-        'u_blurSize', 'u_blurDepth', 'u_depthImageBlurSize',
+    'u_blurSize', 'u_blurDepth', 'u_depthImageBlurSize', 'u_maxScale',
         'u_borderColor', 'u_borderSizeX', 'u_borderSizeY'
     ];
     
@@ -153,6 +153,11 @@ function render() {
     gl.uniform1f(uniforms.u_blurSize, parseFloat(document.getElementById('blurSize').value));
     gl.uniform1f(uniforms.u_blurDepth, parseFloat(document.getElementById('blurDepth').value));
     gl.uniform1f(uniforms.u_depthImageBlurSize, parseFloat(document.getElementById('depthImageBlurSize').value));
+    // 传递最大放大倍率
+    const maxScaleEl = document.getElementById('maxScale');
+    if (maxScaleEl) {
+        gl.uniform1f(uniforms.u_maxScale, parseFloat(maxScaleEl.value));
+    }
     
     const borderColorHex = document.getElementById('borderColor').value;
     const borderColorRgb = hexToRgb(borderColorHex);
@@ -223,7 +228,7 @@ function setupControls() {
     const controls = [
         'threshold', 'protrude', 'x_diff', 'y_diff',
         'scaleX', 'scaleY', 'offsetX', 'offsetY',
-        'blurSize', 'blurDepth', 'depthImageBlurSize',
+    'blurSize', 'blurDepth', 'depthImageBlurSize', 'maxScale',
         'borderSizeX', 'borderSizeY'
     ];
     

--- a/main.js
+++ b/main.js
@@ -60,7 +60,7 @@ function getUniforms() {
         'g_Texture0', 'g_Texture1', 'g_Texture2', 'g_Screen',
         'u_threshold', 'u_protrude', 'u_x_diff', 'u_y_diff',
         'u_scaleX', 'u_scaleY', 'u_offsetX', 'u_offsetY',
-    'u_blurSize', 'u_blurDepth', 'u_depthImageBlurSize', 'u_maxScale',
+    'u_blurSize', 'u_blurDepth', 'u_depthImageBlurSize', 'u_maxScale', 'u_centerX', 'u_centerY',
         'u_borderColor', 'u_borderSizeX', 'u_borderSizeY'
     ];
     
@@ -158,6 +158,13 @@ function render() {
     if (maxScaleEl) {
         gl.uniform1f(uniforms.u_maxScale, parseFloat(maxScaleEl.value));
     }
+    // 传递缩放中心
+    const centerXEl = document.getElementById('centerX');
+    const centerYEl = document.getElementById('centerY');
+    if (centerXEl && centerYEl) {
+        gl.uniform1f(uniforms.u_centerX, parseFloat(centerXEl.value));
+        gl.uniform1f(uniforms.u_centerY, parseFloat(centerYEl.value));
+    }
     
     const borderColorHex = document.getElementById('borderColor').value;
     const borderColorRgb = hexToRgb(borderColorHex);
@@ -229,6 +236,7 @@ function setupControls() {
         'threshold', 'protrude', 'x_diff', 'y_diff',
         'scaleX', 'scaleY', 'offsetX', 'offsetY',
     'blurSize', 'blurDepth', 'depthImageBlurSize', 'maxScale',
+    'centerX', 'centerY',
         'borderSizeX', 'borderSizeY'
     ];
     

--- a/shaders.js
+++ b/shaders.js
@@ -36,6 +36,8 @@ export const fragmentShaderSource = `
     uniform float u_blurDepth;
     uniform float u_depthImageBlurSize;
     uniform float u_maxScale;
+    uniform float u_centerX;
+    uniform float u_centerY;
     
     uniform vec3 u_borderColor;
     uniform float u_borderSizeX, u_borderSizeY;
@@ -84,7 +86,7 @@ export const fragmentShaderSource = `
         vec2 fake3d = vec2(uv.x + xOffset, uv.y + yOffset);
 
         float depthScale = mix(1.0, u_maxScale, clamp(depthMap.r, 0.0, 1.0));
-        vec2 texCenter = vec2(0.5, 0.5);
+        vec2 texCenter = vec2(u_centerX, u_centerY);
         vec2 scaledFake3d = (fake3d - texCenter) / depthScale + texCenter;
 
         if((depthMap.r - 0.5 + u_protrude < 0.) && 

--- a/shaders.js
+++ b/shaders.js
@@ -35,6 +35,7 @@ export const fragmentShaderSource = `
     uniform float u_blurSize;
     uniform float u_blurDepth;
     uniform float u_depthImageBlurSize;
+    uniform float u_maxScale;
     
     uniform vec3 u_borderColor;
     uniform float u_borderSizeX, u_borderSizeY;
@@ -82,6 +83,10 @@ export const fragmentShaderSource = `
         float yOffset = (depthMap.r - 0.5 + u_protrude) * ((valueIdY) * 2.0 / u_threshold);
         vec2 fake3d = vec2(uv.x + xOffset, uv.y + yOffset);
 
+        float depthScale = mix(1.0, u_maxScale, clamp(depthMap.r, 0.0, 1.0));
+        vec2 texCenter = vec2(0.5, 0.5);
+        vec2 scaledFake3d = (fake3d - texCenter) / depthScale + texCenter;
+
         if((depthMap.r - 0.5 + u_protrude < 0.) && 
             (fractCoord.x < u_borderSizeX || fractCoord.y < u_borderSizeY || 
             fractCoord.x > (1. - u_borderSizeX) || fractCoord.y > (1. - u_borderSizeY))) {
@@ -89,9 +94,8 @@ export const fragmentShaderSource = `
         }
 
         vec4 color = depthMap.r < u_blurDepth ? 
-            convolute(mirrored(fake3d), gaussian_blur, u_blurSize) : 
-            texture2D(g_Texture1, fake3d);
-        
+            convolute(mirrored(scaledFake3d), gaussian_blur, u_blurSize) : 
+            texture2D(g_Texture1, scaledFake3d);
         return color;
     }
     


### PR DESCRIPTION
This pull request adds new controls for 3D effect scaling and scaling center, and updates the image transformation logic to support these parameters. It also adjusts the default blur size and ensures the new parameters are properly passed from the UI to the shader.

**3D Effect Scaling Enhancements:**
- Added UI controls in `index.html` for `maxScale`, `centerX`, and `centerY` to allow users to adjust the maximum scale and the scaling center of the 3D effect.
- Updated the fragment shader in `shaders.js` to accept and use the new uniforms `u_maxScale`, `u_centerX`, and `u_centerY` for dynamic scaling based on depth and user-selected center. [[1]](diffhunk://#diff-9b85dd4bd7233b175c93070a7a3ae6d6aae3597565179dbf73537f85d81da122R38-R40) [[2]](diffhunk://#diff-9b85dd4bd7233b175c93070a7a3ae6d6aae3597565179dbf73537f85d81da122R88-R100)

**UI and Data Flow Integration:**
- Modified `main.js` to:
  - Register the new controls in `setupControls` and `getUniforms`. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL63-R63) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL226-R239)
  - Pass the new parameters (`maxScale`, `centerX`, `centerY`) from the UI to the shader in the `render` function.

**Other UI Improvements:**
- Changed the default blur size value in the UI from 10 to 5 for a subtler effect.

Fixes #9 