### PR TITLE
为触摸屏添加拖拽支持

### DIFF
--- a/main.js
+++ b/main.js
@@ -374,6 +374,19 @@ function setupDragControls() {
         e.preventDefault();
     });
 
+    // 触摸开始
+    canvas.addEventListener('touchstart', (e) => {
+        if (e.touches.length === 0) return;
+        const t = e.touches[0];
+        dragging = true;
+        canvas.style.cursor = 'grabbing';
+        startX = t.clientX;
+        startY = t.clientY;
+        startXVal = parseFloat(xSlider.value);
+        startYVal = parseFloat(ySlider.value);
+        e.preventDefault();
+    }, { passive: false });
+
     window.addEventListener('mousemove', (e) => {
         if (!dragging) return;
         const dx = e.clientX - startX;
@@ -384,6 +397,19 @@ function setupDragControls() {
         updateUI(newX, newY);
     });
 
+    // 触摸移动
+    window.addEventListener('touchmove', (e) => {
+        if (!dragging || e.touches.length === 0) return;
+        const t = e.touches[0];
+        const dx = t.clientX - startX;
+        const dy = t.clientY - startY;
+        const { deltaX, deltaY } = pxToDelta(dx, dy);
+        const newX = clamp(startXVal + deltaX, parseFloat(xSlider.min), parseFloat(xSlider.max));
+        const newY = clamp(startYVal + deltaY, parseFloat(ySlider.min), parseFloat(ySlider.max));
+        updateUI(newX, newY);
+        e.preventDefault();
+    }, { passive: false });
+
     function endDrag() {
         if (!dragging) return;
         dragging = false;
@@ -392,6 +418,8 @@ function setupDragControls() {
 
     window.addEventListener('mouseup', endDrag);
     window.addEventListener('mouseleave', endDrag);
+    window.addEventListener('touchend', endDrag);
+    window.addEventListener('touchcancel', endDrag);
 }
 
 // 陀螺仪控制


### PR DESCRIPTION
This pull request adds touch support to the drag controls in `main.js`, making the UI usable on touch devices such as smartphones and tablets. The main changes include handling touch events for starting, moving, and ending drag actions.

Touch event support for drag controls:

* Added a `touchstart` event listener to the `canvas` element to initiate dragging when a touch begins, similar to the existing mouse drag logic.
* Added a `touchmove` event listener to the `window` to update the UI as the user moves their finger, mirroring the mouse move behavior.
* Added `touchend` and `touchcancel` event listeners to the `window` to properly end the drag operation when the touch ends or is cancelled.

Fixes #11 